### PR TITLE
Change vm_instace label to map InstanceHost

### DIFF
--- a/plugins/handler/ceilometer-metrics/main.go
+++ b/plugins/handler/ceilometer-metrics/main.go
@@ -254,9 +254,9 @@ func genLabels(m ceilometer.Metric, publisher string, cNameShards []string) ([]s
 		index++
 	}
 
-	if m.ResourceMetadata.Host != "" {
+	if m.ResourceMetadata.InstanceHost != "" {
 		labelKeys[index] = "vm_instance"
-		labelVals[index] = m.ResourceMetadata.Host
+		labelVals[index] = m.ResourceMetadata.InstanceHost
 		index++
 	}
 


### PR DESCRIPTION
I propose change the vm_instnace label to represent instance_host {compute_hostname} instead of host { publisher_id}

As the ceilometer sample is look like that:

 'resource_metadata': {
         'display_name': 'myserver5', 
         'name': 'tapb55152fe-d8', 
         'instance_id': '9b47bef3-9168-4be4-86b8-adcb29e7c86d', 
         'instance_type': 'cirros256', 
         'host': '1b8dd15d577fdcab2f80cfc3000386768eedb4f8a6d8e77cbe508465', 
         'instance_host': 'ubuntu22', 