### PR TITLE
Install and run node_exporter

### DIFF
--- a/devstack/plugin.sh
+++ b/devstack/plugin.sh
@@ -61,7 +61,14 @@ function init_prometheus {
 	$SG_CORE_CONTAINER_EXECUTABLE run -v $PROMETHEUS_CONF:/etc/prometheus/prometheus.yml --network host --name prometheus -d $PROMETHEUS_CONTAINER_IMAGE --config.file=/etc/prometheus/prometheus.yml --web.enable-admin-api
 }
 
+### node_exporter ###
+function install_node_exporter {
+	$SG_CORE_CONTAINER_EXECUTABLE pull $NODE_EXPORTER_CONTAINER_IMAGE
+}
 
+function init_node_exporter {
+	$SG_CORE_CONTAINER_EXECUTABLE run -d --network host --pid host -v "/:/host:ro,rslave" --name node_exporter $NODE_EXPORTER_CONTAINER_IMAGE --path.rootfs=/host
+}
 # check for service enabled
 if is_service_enabled sg-core; then
 
@@ -126,6 +133,33 @@ if is_service_enabled sg-core; then
 
 		if [[ "$1" == "clean" ]]; then
 			$PROMETHEUS_CONTAINER_EXECUTABLE rmi $PROMETHEUS_CONTAINER_IMAGE
+		fi
+
+	fi
+	if [[ $NODE_EXPORTER_ENABLE = true ]]; then
+		if [[ "$1" == "stack" && "$2" == "pre-install" ]]; then
+			# Set up system services
+			echo_summary "Configuring system services node_exporter"
+			install_container_executable
+
+		elif [[ "$1" == "stack" && "$2" == "install" ]]; then
+			# Perform installation of service source
+			echo_summary "Installing node_exporter"
+			install_node_exporter
+
+		elif [[ "$1" == "stack" && "$2" == "extra" ]]; then
+			# Initialize and start the node_exporter service
+			echo_summary "Initializing node_exporter"
+			init_node_exporter
+		fi
+
+		if [[ "$1" == "unstack" ]]; then
+			$SG_CORE_CONTAINER_EXECUTABLE stop node_exporter
+			$SG_CORE_CONTAINER_EXECUTABLE rm -f node_exporter
+		fi
+
+		if [[ "$1" == "clean" ]]; then
+			$SG_CORE_CONTAINER_EXECUTABLE rmi $NODE_EXPORTER_CONTAINER_IMAGE
 		fi
 
 	fi

--- a/devstack/prometheus-files/scrape_configs/node-exporter
+++ b/devstack/prometheus-files/scrape_configs/node-exporter
@@ -1,0 +1,4 @@
+  - job_name: 'node_exporter'
+
+    static_configs:
+      - targets: ['localhost:9100']

--- a/devstack/settings
+++ b/devstack/settings
@@ -25,10 +25,17 @@ PROMETHEUS_CONTAINER_REPOSITORY=${PROMETHEUS_CONTAINER_REPOSITORY:-quay.io/prome
 PROMETHEUS_CONTAINER_TAG=${PROMETHEUS_CONTAINER_TAG:-latest}
 PROMETHEUS_CONTAINER_IMAGE=$PROMETHEUS_CONTAINER_REPOSITORY:$PROMETHEUS_CONTAINER_TAG
 
+### node_exporter ###
+NODE_EXPORTER=${NODE_EXPORTER:-false}
+
+NODE_EXPORTER_CONTAINER_REPOSITORY=${NODE_EXPORTER_CONTAINER_REPOSITORY:-quay.io/prometheus/node-exporter}
+NODE_EXPORTER_CONTAINER_TAG=${NODE_EXPORTER_CONTAINER_TAG:-latest}
+NODE_EXPORTER_CONTAINER_IMAGE=$NODE_EXPORTER_CONTAINER_REPOSITORY:$NODE_EXPORTER_CONTAINER_TAG
+
 # It's assumed, that each service scrape target has its own same named
 # file in the scrape_configs folder
 # List of "," delimited names
-# Currently supported values are "sg-core" and "prometheus"
+# Currently supported values are "sg-core" , "node-exporter" and "prometheus"
 PROMETHEUS_SERVICE_SCRAPE_TARGETS=${PROMETHEUS_SERVICE_SCRAPE_TARGETS:="sg-core"}
 
 # List of "," delimited targets. Each target is <ip>:<port>


### PR DESCRIPTION
In order to collect metrics from the compute node in DevStack environment we need to install node_exporter on each node and add these nodes to scrape_configs in prometheus.yaml.

This pr automates installation and running of node exporter on the node.

In order to add it to scrape_configs, we need to set
    PROMETHEUS_SERVICE_SCRAPE_TARGETS="prometheus,node-exporter"