### PR TITLE
[zuul] Update project name in zuul.yaml

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,5 +1,5 @@
 ---
 - project:
-    name: infrawatch/sg-core
+    name: openstack-k8s-operators/sg-core
     templates:
       - stf-crc-jobs


### PR DESCRIPTION
The project name refers to the infrawatch version, so the config is not applied to openstack-k8s-operators version of sg-core
This commit updates the project name so that the config is applied to o-k-o