### PR TITLE
Mention Ceilometer and Rsyslog in generater README

### DIFF
--- a/generator/README.md
+++ b/generator/README.md
@@ -1,6 +1,6 @@
-# Generate collectd JSON AMQP messages
+# Generate collectd JSON AMQP or Ceilometer or Rsyslog messages
 
-Connects to a QDR.  Generates collectd JSON formated metrics.  Sends the metrics to the bridge.
+Connects to a QDR.  Generates either collectd JSON formated metrics or Ceilometer metrics or Rsyslog logs.  Sends the data to the bridge.
 
 ## Build
 


### PR DESCRIPTION
Modifies the generator README to add mentions of Ceilometer and Rsyslog, which it's also capable of generating, but these capabilities were added later.

This PR isn't important at all, it's aimed mostly to see if automatic sg-core image builds on PR merge work.