### PR TITLE
Drop prometheus vars in favor of devstack-plugin-prometheus

### DIFF
--- a/devstack/prometheus-files/prometheus.yml
+++ b/devstack/prometheus-files/prometheus.yml
@@ -1,4 +1,0 @@
-global:
-  scrape_interval:     15s # By default, scrape targets every 15 seconds.
-
-scrape_configs:

--- a/devstack/prometheus-files/scrape_configs/prometheus
+++ b/devstack/prometheus-files/scrape_configs/prometheus
@@ -1,4 +1,0 @@
-  - job_name: 'prometheus'
-
-    static_configs:
-      - targets: ['localhost:9090']

--- a/devstack/prometheus-files/scrape_configs/sg-core
+++ b/devstack/prometheus-files/scrape_configs/sg-core
@@ -1,4 +1,0 @@
-  - job_name: 'sg-core'
-
-    static_configs:
-      - targets: ['localhost:3000']

--- a/devstack/settings
+++ b/devstack/settings
@@ -14,20 +14,3 @@ SG_CORE_WORKDIR=$SG_CORE_DIR/devstack/workdir
 SG_CORE_CONTAINER_REPOSITORY=${SG_CORE_CONTAINER_REPOSITORY:-quay.io/openstack-k8s-operators/sg-core}
 SG_CORE_CONTAINER_TAG=${SG_CORE_CONTAINER_TAG:-latest}
 SG_CORE_CONTAINER_IMAGE=$SG_CORE_CONTAINER_REPOSITORY:$SG_CORE_CONTAINER_TAG
-
-### prometheus ###
-PROMETHEUS_ENABLE=${PROMETHEUS_ENABLE:-true}
-
-PROMETHEUS_CLIENT_CONF_DIR=${PROMETHEUS_CLIENT_CONF_DIR:-/etc/openstack}
-PROMETHEUS_CONF_DIR=${PROMETHEUS_CONF_DIR:-/etc/prometheus}
-PROMETHEUS_CONFIG_FILE=$PROMETHEUS_CONF_DIR/prometheus.yml
-
-# It's assumed, that each service scrape target has its own same named
-# file in the scrape_configs folder
-# List of "," delimited names
-# Currently supported values are "sg-core" and "prometheus"
-PROMETHEUS_SERVICE_SCRAPE_TARGETS=${PROMETHEUS_SERVICE_SCRAPE_TARGETS:="sg-core"}
-
-# List of "," delimited targets. Each target is <ip>:<port>
-PROMETHEUS_CUSTOM_SCRAPE_TARGETS=${PROMETHEUS_CUSTOM_SCRAPE_TARGETS:-""}
-


### PR DESCRIPTION
Let keep the sg_core devstack plugin to install sg_core service only and use devstack-plugin-prometheus to install /configure prometheus.
    
https://review.opendev.org/c/openstack/devstack-plugin-prometheus/+/950476 adds the support for passing custom prometheus scrape target.
    
 For sg_core, we can use
 ```
 PROMETHEUS_CUSTOM_SCRAPE_TARGETS="localhost:3000"
 ```
 to send metrics to prometheus.
    
 Note: this pr also adds commands to copy prometheus.yaml file to /etc/openstack, needed by sg_core to communicate with prometheus.

It is being tested here: https://review.opendev.org/c/openstack/telemetry-tempest-plugin/+/950477

Resolves: [OSPRH-16823](https://issues.redhat.com//browse/OSPRH-16823)
