### PR TITLE
[OSPRH-28762] Add AZ and flavor labels for LB/compute metrics

### DIFF
--- a/plugins/handler/ceilometer-metrics/main.go
+++ b/plugins/handler/ceilometer-metrics/main.go
@@ -185,8 +185,8 @@ func genName(cNameShards []string) string {
 
 func genLabels(m ceilometer.Metric, publisher string, cNameShards []string) ([]string, []string) {
 	//  TODO: set to persistent var
-	labelKeys := make([]string, 12+len(m.ResourceMetadata.UserMetadata))
-	labelVals := make([]string, 12+len(m.ResourceMetadata.UserMetadata))
+	labelKeys := make([]string, 15+len(m.ResourceMetadata.UserMetadata))
+	labelVals := make([]string, 15+len(m.ResourceMetadata.UserMetadata))
 	plugin := cNameShards[0]
 	pluginVal := m.ResourceID
 	if len(cNameShards) > 2 {
@@ -283,6 +283,27 @@ func genLabels(m ceilometer.Metric, publisher string, cNameShards []string) ([]s
 		for key, value := range m.ResourceMetadata.UserMetadata {
 			labelKeys[index] = key
 			labelVals[index] = value
+			index++
+		}
+	}
+
+	// Add availability_zone label for loadbalancer metrics
+	if m.ResourceMetadata.AvailabilityZone != "" {
+		labelKeys[index] = "availability_zone"
+		labelVals[index] = m.ResourceMetadata.AvailabilityZone
+		index++
+	}
+
+	// Add flavor_id and flavor_name labels for compute metrics
+	if m.ResourceMetadata.Flavor != nil {
+		if m.ResourceMetadata.Flavor.ID != "" {
+			labelKeys[index] = "flavor_id"
+			labelVals[index] = m.ResourceMetadata.Flavor.ID
+			index++
+		}
+		if m.ResourceMetadata.Flavor.Name != "" {
+			labelKeys[index] = "flavor_name"
+			labelVals[index] = m.ResourceMetadata.Flavor.Name
 			index++
 		}
 	}

--- a/plugins/handler/ceilometer-metrics/main_test.go
+++ b/plugins/handler/ceilometer-metrics/main_test.go
@@ -150,6 +150,72 @@ func TestGenLabelsSizes(t *testing.T) {
 		assert.Equal(t, len(labelKeys), 10)
 	})
 
+	t.Run("compute with flavor labels", func(t *testing.T) {
+		metric := ceilometer.Metric{
+			Source:        "openstack",
+			CounterName:   "cpu",
+			CounterType:   "gauge",
+			CounterUnit:   "ns",
+			CounterVolume: 1.048e+10,
+			UserID:        "user_id",
+			UserName:      "user_name",
+			ProjectID:     "bc25bb8f9160407ca2fdb65c5380c7f8",
+			ProjectName:   "test_project",
+			ResourceID:    "b8b5b487-33cf-4f54-8c24-25f4d075b149",
+			Timestamp:     "2021-03-30T15:20:19.891893",
+			ResourceMetadata: ceilometer.Metadata{
+				Host:        "hostid123",
+				DisplayName: "test-vm",
+				Name:        "instance-00000003",
+				Flavor: &ceilometer.Flavor{
+					ID:   "d1",
+					Name: "ds512M",
+				},
+			},
+		}
+
+		labelKeys, labelVals := genLabels(metric, "controller-0", []string{"cpu"})
+
+		assert.Equal(t, len(labelKeys), len(labelVals))
+
+		// should have 14 labels: cpu, publisher, type, counter, project, project_name, user, user_name, unit, resource, vm_instance, resource_name, flavor_id, flavor_name
+		assert.Equal(t, len(labelKeys), 14)
+
+		assert.Equal(t, labelKeys[12], "flavor_id")
+		assert.Equal(t, labelVals[12], "d1")
+		assert.Equal(t, labelKeys[13], "flavor_name")
+		assert.Equal(t, labelVals[13], "ds512M")
+	})
+
+	t.Run("loadbalancer with availability_zone", func(t *testing.T) {
+		metric := ceilometer.Metric{
+			Source:        "openstack",
+			CounterName:   "loadbalancer.operating",
+			CounterType:   "gauge",
+			CounterUnit:   "status",
+			CounterVolume: 3,
+			ProjectID:     "bc25bb8f9160407ca2fdb65c5380c7f8",
+			ProjectName:   "test_project",
+			ResourceID:    "bb4e7d03-4e51-4ff3-8c13-a2a34a62226b",
+			Timestamp:     "2021-03-30T15:20:19.891893",
+			ResourceMetadata: ceilometer.Metadata{
+				DisplayName:      "test-lb",
+				AvailabilityZone: "nova-az",
+			},
+		}
+
+		labelKeys, labelVals := genLabels(metric, "controller-0", []string{"loadbalancer", "operating"})
+
+		assert.Equal(t, len(labelKeys), len(labelVals))
+
+		// should have 10 labels: loadbalancer, publisher, type, counter, project, project_name, unit, resource, resource_name, availability_zone
+		assert.Equal(t, len(labelKeys), 10)
+
+		// verify availability_zone is present at the end
+		assert.Equal(t, labelKeys[9], "availability_zone")
+		assert.Equal(t, labelVals[9], "nova-az")
+	})
+
 	t.Run("exhaustive labels", func(t *testing.T) {
 		metric := ceilometer.Metric{
 			Source:        "openstack",

--- a/plugins/handler/ceilometer-metrics/messages/metric-tests.json
+++ b/plugins/handler/ceilometer-metrics/messages/metric-tests.json
@@ -4,7 +4,7 @@
       "testInput": {
         "request": {
           "oslo.version": "2.0",
-          "oslo.message": "{\"message_id\": \"37f64423-db31-4cfb-8c9d-06f9c0fad04a\", \"publisher_id\": \"telemetry.publisher.controller-0.redhat.local\", \"event_type\": \"metering\", \"priority\": \"SAMPLE\", \"payload\": [{\"source\": \"openstack\", \"counter_name\": \"disk.ephemeral.size\", \"counter_type\": \"gauge\", \"counter_unit\": \"GB\", \"counter_volume\": 0, \"user_id\": \"3ee72fcd74aa4439bb07fa69f1bc7169\", \"project_id\": \"e56191ef77744c599dbcecae6af176bb\", \"user_name\": \"test_user\", \"project_name\": \"test_project\", \"resource_id\": \"d8bd99b6-6fd8-4c02-a2e3-efbf596df636\", \"timestamp\": \"2020-09-14T16:12:49.939250+00:00\", \"resource_metadata\": {\"host\": \"compute-0.redhat.local\", \"flavor_id\": \"71cd0af1-afd3-4ee4-b918-cec05bf89578\", \"flavor_name\": \"m1.tiny\", \"display_name\": \"new-instance\", \"name\": \"instance-0000001\", \"image_ref\": \"45333e02-643d-4f4f-a817-065060753983\", \"launched_at\": \"2020-09-14T16:12:49.839122\", \"created_at\": \"2020-09-14 16:12:39+00:00\"}, \"message_id\": \"22a54880-f6a5-11ea-b0f2-525400971e97\", \"monotonic_time\": null, \"message_signature\": \"be55d63bd5d876a62ab52824104128eedfa0619386e8569e326ccef4dcf0d9db\"}, {\"source\": \"openstack\", \"counter_name\": \"disk.root.size\", \"counter_type\": \"gauge\", \"counter_unit\": \"GB\", \"counter_volume\": 1, \"user_id\": \"3ee72fcd74aa4439bb07fa69f1bc7169\", \"project_id\": \"e56191ef77744c599dbcecae6af176bb\", \"user_name\": \"test_user\", \"project_name\": \"test_project\", \"resource_id\": \"d8bd99b6-6fd8-4c02-a2e3-efbf596df636\", \"timestamp\": \"2020-09-14T16:12:49.939250+00:00\", \"resource_metadata\": {\"host\": \"compute-0.redhat.local\", \"flavor_id\": \"71cd0af1-afd3-4ee4-b918-cec05bf89578\", \"flavor_name\": \"m1.tiny\", \"display_name\": \"new-instance\", \"name\": \"instance-0000001\", \"image_ref\": \"45333e02-643d-4f4f-a817-065060753983\", \"launched_at\": \"2020-09-14T16:12:49.839122\", \"created_at\": \"2020-09-14 16:12:39+00:00\"}, \"message_id\": \"22a55c80-f6a5-11ea-b0f2-525400971e97\", \"monotonic_time\": null, \"message_signature\": \"bc0b987d71fe9f0d5d902347f22a0a20b2d975344b4c948572cae4dae553e960\"}, {\"source\": \"openstack\", \"counter_name\": \"compute.instance.booting.time\", \"counter_type\": \"gauge\", \"counter_unit\": \"sec\", \"counter_volume\": 10.839122, \"user_id\": null, \"project_id\": \"e56191ef77744c599dbcecae6af176bb\", \"user_name\": null, \"project_name\": \"test_project\", \"resource_id\": \"d8bd99b6-6fd8-4c02-a2e3-efbf596df636\", \"timestamp\": \"2020-09-14T16:12:49.939250+00:00\", \"resource_metadata\": {\"host\": \"compute-0.redhat.local\", \"flavor_id\": \"71cd0af1-afd3-4ee4-b918-cec05bf89578\", \"flavor_name\": \"m1.tiny\", \"display_name\": \"new-instance\", \"name\": \"instance-0000001\", \"image_ref\": \"45333e02-643d-4f4f-a817-065060753983\", \"launched_at\": \"2020-09-14T16:12:49.839122\", \"created_at\": \"2020-09-14 16:12:39+00:00\"}, \"message_id\": \"22a574d6-f6a5-11ea-b0f2-525400971e97\", \"monotonic_time\": null, \"message_signature\": \"fd7f1e2fdb34b7beb836d0ead178289f7c36f39bcd68acfd0719848667c58a13\"}, {\"source\": \"openstack\", \"counter_name\": \"vcpus\", \"counter_type\": \"gauge\", \"counter_unit\": \"vcpu\", \"counter_volume\": 2, \"user_id\": \"3ee72fcd74aa4439bb07fa69f1bc7169\", \"project_id\": \"e56191ef77744c599dbcecae6af176bb\", \"user_name\": \"test_user\", \"project_name\": \"test_project\", \"resource_id\": \"d8bd99b6-6fd8-4c02-a2e3-efbf596df636\", \"timestamp\": \"2020-09-14T16:12:49.939250+00:00\", \"resource_metadata\": {\"host\": \"compute-0.redhat.local\", \"flavor_id\": \"71cd0af1-afd3-4ee4-b918-cec05bf89578\", \"flavor_name\": \"m1.tiny\", \"display_name\": \"new-instance\", \"image_ref\": \"45333e02-643d-4f4f-a817-065060753983\", \"launched_at\": \"2020-09-14T16:12:49.839122\", \"created_at\": \"2020-09-14 16:12:39+00:00\"}, \"message_id\": \"22a5821e-f6a5-11ea-b0f2-525400971e97\", \"monotonic_time\": null, \"message_signature\": \"d3f107c2ef6bb1b06e1a9975d1f1ff0bdc51432adff39403db2a1f6a9773b99d\"}, {\"source\": \"openstack\", \"counter_name\": \"memory\", \"counter_type\": \"gauge\", \"counter_unit\": \"MB\", \"counter_volume\": 512, \"user_id\": \"3ee72fcd74aa4439bb07fa69f1bc7169\", \"project_id\": \"e56191ef77744c599dbcecae6af176bb\", \"user_name\": \"test_user\", \"project_name\": \"test_project\", \"resource_id\": \"d8bd99b6-6fd8-4c02-a2e3-efbf596df636\", \"timestamp\": \"2020-09-14T16:12:49.939250+00:00\", \"resource_metadata\": {\"host\": \"compute-0.redhat.local\", \"flavor_id\": \"71cd0af1-afd3-4ee4-b918-cec05bf89578\", \"flavor_name\": \"m1.tiny\", \"name\": \"instance-0000001\", \"image_ref\": \"45333e02-643d-4f4f-a817-065060753983\", \"launched_at\": \"2020-09-14T16:12:49.839122\", \"created_at\": \"2020-09-14 16:12:39+00:00\"}, \"message_id\": \"22a591dc-f6a5-11ea-b0f2-525400971e97\", \"monotonic_time\": null, \"message_signature\": \"9dcf78e3cd43e7fcd66cda5cf33511150e79a086a634bd9d087bb567e4985980\"}, {\"source\": \"openstack\", \"counter_name\": \"cpu\", \"counter_type\": \"gauge\", \"counter_unit\": \"ms\", \"counter_volume\": 512, \"user_id\": \"3ee72fcd74aa4439bb07fa69f1bc7169\", \"project_id\": \"e56191ef77744c599dbcecae6af176bb\", \"user_name\": \"test_user\", \"project_name\": \"test_project\", \"resource_id\": \"d8bd99b6-6fd8-4c02-a2e3-efbf596df636\", \"timestamp\": \"2020-09-14T16:12:49.939250+00:00\", \"resource_metadata\": {\"host\": \"compute-0.redhat.local\", \"flavor_id\": \"71cd0af1-afd3-4ee4-b918-cec05bf89578\", \"flavor_name\": \"m1.tiny\", \"name\": \"instance-0000001\", \"image_ref\": \"45333e02-643d-4f4f-a817-065060753983\", \"launched_at\": \"2020-09-14T16:12:49.839122\", \"created_at\": \"2020-09-14 16:12:39+00:00\", \"user_metadata\": {\"server_group\": \"group1\", \"some_other_user_metadata\": \"value\"}}, \"message_id\": \"22a591dc-f6a5-11ea-b0f2-525400971e97\", \"monotonic_time\": null, \"message_signature\": \"9dcf78e3cd43e7fcd66cda5cf33511150e79a086a634bd9d087bb567e4985980\"}], \"timestamp\": \"2020-09-14 16:12:49.954128\"}"
+          "oslo.message": "{\"message_id\": \"37f64423-db31-4cfb-8c9d-06f9c0fad04a\", \"publisher_id\": \"telemetry.publisher.controller-0.redhat.local\", \"event_type\": \"metering\", \"priority\": \"SAMPLE\", \"payload\": [{\"source\": \"openstack\", \"counter_name\": \"disk.ephemeral.size\", \"counter_type\": \"gauge\", \"counter_unit\": \"GB\", \"counter_volume\": 0, \"user_id\": \"3ee72fcd74aa4439bb07fa69f1bc7169\", \"project_id\": \"e56191ef77744c599dbcecae6af176bb\", \"user_name\": \"test_user\", \"project_name\": \"test_project\", \"resource_id\": \"d8bd99b6-6fd8-4c02-a2e3-efbf596df636\", \"timestamp\": \"2020-09-14T16:12:49.939250+00:00\", \"resource_metadata\": {\"host\": \"compute-0.redhat.local\", \"flavor_id\": \"71cd0af1-afd3-4ee4-b918-cec05bf89578\", \"flavor_name\": \"m1.tiny\", \"display_name\": \"new-instance\", \"name\": \"instance-0000001\", \"image_ref\": \"45333e02-643d-4f4f-a817-065060753983\", \"launched_at\": \"2020-09-14T16:12:49.839122\", \"created_at\": \"2020-09-14 16:12:39+00:00\"}, \"message_id\": \"22a54880-f6a5-11ea-b0f2-525400971e97\", \"monotonic_time\": null, \"message_signature\": \"be55d63bd5d876a62ab52824104128eedfa0619386e8569e326ccef4dcf0d9db\"}, {\"source\": \"openstack\", \"counter_name\": \"disk.root.size\", \"counter_type\": \"gauge\", \"counter_unit\": \"GB\", \"counter_volume\": 1, \"user_id\": \"3ee72fcd74aa4439bb07fa69f1bc7169\", \"project_id\": \"e56191ef77744c599dbcecae6af176bb\", \"user_name\": \"test_user\", \"project_name\": \"test_project\", \"resource_id\": \"d8bd99b6-6fd8-4c02-a2e3-efbf596df636\", \"timestamp\": \"2020-09-14T16:12:49.939250+00:00\", \"resource_metadata\": {\"host\": \"compute-0.redhat.local\", \"flavor_id\": \"71cd0af1-afd3-4ee4-b918-cec05bf89578\", \"flavor_name\": \"m1.tiny\", \"display_name\": \"new-instance\", \"name\": \"instance-0000001\", \"image_ref\": \"45333e02-643d-4f4f-a817-065060753983\", \"launched_at\": \"2020-09-14T16:12:49.839122\", \"created_at\": \"2020-09-14 16:12:39+00:00\"}, \"message_id\": \"22a55c80-f6a5-11ea-b0f2-525400971e97\", \"monotonic_time\": null, \"message_signature\": \"bc0b987d71fe9f0d5d902347f22a0a20b2d975344b4c948572cae4dae553e960\"}, {\"source\": \"openstack\", \"counter_name\": \"compute.instance.booting.time\", \"counter_type\": \"gauge\", \"counter_unit\": \"sec\", \"counter_volume\": 10.839122, \"user_id\": null, \"project_id\": \"e56191ef77744c599dbcecae6af176bb\", \"user_name\": null, \"project_name\": \"test_project\", \"resource_id\": \"d8bd99b6-6fd8-4c02-a2e3-efbf596df636\", \"timestamp\": \"2020-09-14T16:12:49.939250+00:00\", \"resource_metadata\": {\"host\": \"compute-0.redhat.local\", \"flavor_id\": \"71cd0af1-afd3-4ee4-b918-cec05bf89578\", \"flavor_name\": \"m1.tiny\", \"display_name\": \"new-instance\", \"name\": \"instance-0000001\", \"image_ref\": \"45333e02-643d-4f4f-a817-065060753983\", \"launched_at\": \"2020-09-14T16:12:49.839122\", \"created_at\": \"2020-09-14 16:12:39+00:00\"}, \"message_id\": \"22a574d6-f6a5-11ea-b0f2-525400971e97\", \"monotonic_time\": null, \"message_signature\": \"fd7f1e2fdb34b7beb836d0ead178289f7c36f39bcd68acfd0719848667c58a13\"}, {\"source\": \"openstack\", \"counter_name\": \"vcpus\", \"counter_type\": \"gauge\", \"counter_unit\": \"vcpu\", \"counter_volume\": 2, \"user_id\": \"3ee72fcd74aa4439bb07fa69f1bc7169\", \"project_id\": \"e56191ef77744c599dbcecae6af176bb\", \"user_name\": \"test_user\", \"project_name\": \"test_project\", \"resource_id\": \"d8bd99b6-6fd8-4c02-a2e3-efbf596df636\", \"timestamp\": \"2020-09-14T16:12:49.939250+00:00\", \"resource_metadata\": {\"host\": \"compute-0.redhat.local\", \"flavor_id\": \"71cd0af1-afd3-4ee4-b918-cec05bf89578\", \"flavor_name\": \"m1.tiny\", \"display_name\": \"new-instance\", \"image_ref\": \"45333e02-643d-4f4f-a817-065060753983\", \"launched_at\": \"2020-09-14T16:12:49.839122\", \"created_at\": \"2020-09-14 16:12:39+00:00\"}, \"message_id\": \"22a5821e-f6a5-11ea-b0f2-525400971e97\", \"monotonic_time\": null, \"message_signature\": \"d3f107c2ef6bb1b06e1a9975d1f1ff0bdc51432adff39403db2a1f6a9773b99d\"}, {\"source\": \"openstack\", \"counter_name\": \"memory\", \"counter_type\": \"gauge\", \"counter_unit\": \"MB\", \"counter_volume\": 512, \"user_id\": \"3ee72fcd74aa4439bb07fa69f1bc7169\", \"project_id\": \"e56191ef77744c599dbcecae6af176bb\", \"user_name\": \"test_user\", \"project_name\": \"test_project\", \"resource_id\": \"d8bd99b6-6fd8-4c02-a2e3-efbf596df636\", \"timestamp\": \"2020-09-14T16:12:49.939250+00:00\", \"resource_metadata\": {\"host\": \"compute-0.redhat.local\", \"flavor_id\": \"71cd0af1-afd3-4ee4-b918-cec05bf89578\", \"flavor_name\": \"m1.tiny\", \"name\": \"instance-0000001\", \"image_ref\": \"45333e02-643d-4f4f-a817-065060753983\", \"launched_at\": \"2020-09-14T16:12:49.839122\", \"created_at\": \"2020-09-14 16:12:39+00:00\"}, \"message_id\": \"22a591dc-f6a5-11ea-b0f2-525400971e97\", \"monotonic_time\": null, \"message_signature\": \"9dcf78e3cd43e7fcd66cda5cf33511150e79a086a634bd9d087bb567e4985980\"}, {\"source\": \"openstack\", \"counter_name\": \"cpu\", \"counter_type\": \"gauge\", \"counter_unit\": \"ms\", \"counter_volume\": 512, \"user_id\": \"3ee72fcd74aa4439bb07fa69f1bc7169\", \"project_id\": \"e56191ef77744c599dbcecae6af176bb\", \"user_name\": \"test_user\", \"project_name\": \"test_project\", \"resource_id\": \"d8bd99b6-6fd8-4c02-a2e3-efbf596df636\", \"timestamp\": \"2020-09-14T16:12:49.939250+00:00\", \"resource_metadata\": {\"host\": \"compute-0.redhat.local\", \"flavor_id\": \"71cd0af1-afd3-4ee4-b918-cec05bf89578\", \"flavor_name\": \"m1.tiny\", \"name\": \"instance-0000001\", \"image_ref\": \"45333e02-643d-4f4f-a817-065060753983\", \"launched_at\": \"2020-09-14T16:12:49.839122\", \"created_at\": \"2020-09-14 16:12:39+00:00\", \"user_metadata\": {\"server_group\": \"group1\", \"some_other_user_metadata\": \"value\"}}, \"message_id\": \"22a591dc-f6a5-11ea-b0f2-525400971e97\", \"monotonic_time\": null, \"message_signature\": \"9dcf78e3cd43e7fcd66cda5cf33511150e79a086a634bd9d087bb567e4985980\"}, {\"source\": \"openstack\", \"counter_name\": \"loadbalancer.operating\", \"counter_type\": \"gauge\", \"counter_unit\": \"status\", \"counter_volume\": 3, \"user_id\": null, \"project_id\": \"bc25bb8f9160407ca2fdb65c5380c7f8\", \"user_name\": null, \"project_name\": \"test_project\", \"resource_id\": \"bb4e7d03-4e51-4ff3-8c13-a2a34a62226b\", \"timestamp\": \"2020-09-14T16:12:49.939250+00:00\", \"resource_metadata\": {\"display_name\": \"test-lb\", \"availability_zone\": \"nova-az\"}, \"message_id\": \"ee123456-abcd-1234-abcd-123456789012\", \"monotonic_time\": null, \"message_signature\": \"dummy\"}, {\"source\": \"openstack\", \"counter_name\": \"cpu\", \"counter_type\": \"gauge\", \"counter_unit\": \"ns\", \"counter_volume\": 10480000000, \"user_id\": \"d013426b136547009dd638389f65d160\", \"project_id\": \"bc25bb8f9160407ca2fdb65c5380c7f8\", \"user_name\": \"test_user\", \"project_name\": \"test_project\", \"resource_id\": \"b8b5b487-33cf-4f54-8c24-25f4d075b149\", \"timestamp\": \"2020-09-14T16:12:49.939250+00:00\", \"resource_metadata\": {\"host\": \"hostid123\", \"display_name\": \"test-vm\", \"name\": \"instance-00000003\", \"flavor\": {\"id\": \"d1\", \"name\": \"ds512M\"}}, \"message_id\": \"dd123456-abcd-1234-abcd-123456789012\", \"monotonic_time\": null, \"message_signature\": \"dummy\"}], \"timestamp\": \"2020-09-14 16:12:49.954128\"}"
         },
         "context": {}
       },
@@ -218,6 +218,76 @@
           "Type": 2,
           "Interval": 10000000000,
           "Value": 512
+        },
+        {
+          "Name": "ceilometer_loadbalancer_operating",
+          "LabelKeys": [
+            "loadbalancer",
+            "publisher",
+            "type",
+            "counter",
+            "project",
+            "project_name",
+            "unit",
+            "resource",
+            "resource_name",
+            "availability_zone"
+          ],
+          "LabelVals": [
+            "operating",
+            "telemetry.publisher.controller-0.redhat.local",
+            "loadbalancer",
+            "loadbalancer.operating",
+            "bc25bb8f9160407ca2fdb65c5380c7f8",
+            "test_project",
+            "status",
+            "bb4e7d03-4e51-4ff3-8c13-a2a34a62226b",
+            "test-lb",
+            "nova-az"
+          ],
+          "Time": 1600099969,
+          "Type": 2,
+          "Interval": 10000000000,
+          "Value": 3
+        },
+        {
+          "Name": "ceilometer_cpu",
+          "LabelKeys": [
+            "cpu",
+            "publisher",
+            "type",
+            "counter",
+            "project",
+            "project_name",
+            "user",
+            "user_name",
+            "unit",
+            "resource",
+            "vm_instance",
+            "resource_name",
+            "flavor_id",
+            "flavor_name"
+          ],
+          "LabelVals": [
+            "b8b5b487-33cf-4f54-8c24-25f4d075b149",
+            "telemetry.publisher.controller-0.redhat.local",
+            "cpu",
+            "cpu",
+            "bc25bb8f9160407ca2fdb65c5380c7f8",
+            "test_project",
+            "d013426b136547009dd638389f65d160",
+            "test_user",
+            "ns",
+            "b8b5b487-33cf-4f54-8c24-25f4d075b149",
+            "hostid123",
+            "test-vm:instance-00000003",
+            "d1",
+            "ds512M"
+          ],
+          "Time": 1600099969,
+          "Type": 2,
+          "Interval": 10000000000,
+          "Value": 1.048e+10
         }
       ]
     }

--- a/plugins/handler/ceilometer-metrics/pkg/ceilometer/ceilometer.go
+++ b/plugins/handler/ceilometer-metrics/pkg/ceilometer/ceilometer.go
@@ -16,12 +16,19 @@ var (
 )
 
 // Metedata represents metadataof a metric from ceilometer
+type Flavor struct {
+	ID   string `json:"id" msgpack:"id"`
+	Name string `json:"name" msgpack:"name"`
+}
+
 type Metadata struct {
-	Host         string            `json:"host" msgpack:"host"`
-	Name         string            `json:"name" msgpack:"name"`
-	DisplayName  string            `json:"display_name" msgpack:"display_name"`
-	InstanceHost string            `json:"instance_host" msgpack:"instance_host"`
-	UserMetadata map[string]string `json:"user_metadata" msgpack:"user_metadata"`
+	Host             string            `json:"host" msgpack:"host"`
+	Name             string            `json:"name" msgpack:"name"`
+	DisplayName      string            `json:"display_name" msgpack:"display_name"`
+	InstanceHost     string            `json:"instance_host" msgpack:"instance_host"`
+	Flavor           *Flavor           `json:"flavor" msgpack:"flavor"`
+	AvailabilityZone string            `json:"availability_zone" msgpack:"availability_zone"`
+	UserMetadata     map[string]string `json:"user_metadata" msgpack:"user_metadata"`
 }
 
 // Metric represents a single metric from ceilometer for unmarshalling


### PR DESCRIPTION
Parse availability_zone, flavor_id, and flavor_name from ceilometer resource_metadata and expose them as Prometheus labels in the sg-core ceilometer handler plugin. This brings sg-core's metric output to parity with ceilometer's built-in prometheus exporter.

- Add AvailabilityZone field to Metadata struct
- Add Flavor struct with ID and Name fields
- Emit availability_zone, flavor_id, flavor_name labels in genLabels()
- Increase pre-allocated label array size 12 to 15
- Add LB and compute test data to JSON fixtures
- Add genLabels unit tests for LB and compute

Generated-By: Claude-Code claude-opus-4-6