### PR TITLE
Add Zuul CI for container builds and functional tests

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,5 +1,13 @@
 ---
 - project:
     name: openstack-k8s-operators/sg-core
-    templates:
-      - stf-crc-jobs
+    github-check:
+      jobs:
+        - telemetry-container-image-content-provider
+        - telemetry-openstack-meta-content-provider-master:
+            override-checkout: main
+        - functional-tests-osp18:
+            override-checkout: master
+            dependencies:
+              - telemetry-openstack-meta-content-provider-master
+              - telemetry-container-image-content-provider

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,13 +1,41 @@
 ---
+# TODO: Remove the inlined job definition once
+# infrawatch/feature-verification-tests#345 merges.
+- job:
+    name: telemetry-container-image-content-provider-test
+    parent: cifmw-base-minimal
+    description: |
+      Build sg-core and mysqld-exporter container images from the
+      current change and serve them from a local registry for
+      dependent jobs.
+    required-projects:
+      - name: openstack-k8s-operators/ci-framework
+        override-checkout: main
+      - name: openstack-k8s-operators/sg-core
+      - name: openstack-k8s-operators/mysqld_exporter
+    run:
+      - ci/playbooks/container-image-content-provider.yml
+    vars:
+      container_images:
+        - src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/sg-core"
+          name: sg-core
+          update_var: cifmw_update_containers_ceilometersgcoreImage
+        - src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/prometheus-podman-exporter"
+          name: prometheus-podman-exporter
+          update_var: cifmw_update_containers_edpmpodmanexporterImage
+        - src: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/mysqld_exporter"
+          name: mysqld-exporter
+          update_var: cifmw_update_containers_ceilometermysqldexporterImage
+
 - project:
     name: openstack-k8s-operators/sg-core
     github-check:
       jobs:
-        - telemetry-container-image-content-provider
+        - telemetry-container-image-content-provider-test
         - telemetry-openstack-meta-content-provider-master:
             override-checkout: main
         - functional-tests-osp18:
             override-checkout: master
             dependencies:
               - telemetry-openstack-meta-content-provider-master
-              - telemetry-container-image-content-provider
+              - telemetry-container-image-content-provider-test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+IMG ?= quay.io/openstack-k8s-operators/sg-core:latest
+
+.PHONY: docker-build
+docker-build: ## Build container image
+	podman build -t ${IMG} -f build/Dockerfile .
+
+.PHONY: docker-push
+docker-push: ## Push container image
+	podman push ${IMG}

--- a/ci/playbooks/container-image-build.yml
+++ b/ci/playbooks/container-image-build.yml
@@ -1,0 +1,28 @@
+---
+- name: "Get commit SHA for {{ container_image.name }}"
+  ansible.builtin.command:
+    cmd: git show-ref --head --hash head
+    chdir: "{{ container_image.src }}"
+  register: _container_sha
+
+- name: "Set image reference for {{ container_image.name }}"
+  ansible.builtin.set_fact:
+    _container_image_url: "{{ cifmw_rp_registry_ip }}:5001/{{ container_image.name }}:{{ _container_sha.stdout | trim }}"
+
+- name: "Build {{ container_image.name }}"
+  ansible.builtin.command:
+    cmd: >-
+      make docker-build
+      IMG={{ _container_image_url }}
+    chdir: "{{ container_image.src }}"
+
+- name: "Push {{ container_image.name }}"
+  ansible.builtin.command:
+    cmd: >-
+      make docker-push
+      IMG={{ _container_image_url }}
+    chdir: "{{ container_image.src }}"
+
+- name: "Record built image {{ container_image.name }}"
+  ansible.builtin.set_fact:
+    _built_images: "{{ _built_images | default([]) + [{'name': container_image.name, 'update_var': container_image.update_var, 'url': _container_image_url}] }}"

--- a/ci/playbooks/container-image-content-provider.yml
+++ b/ci/playbooks/container-image-content-provider.yml
@@ -1,0 +1,26 @@
+---
+- name: Build and serve container images from review
+  hosts: "{{ cifmw_target_host | default('controller') }}"
+  gather_facts: true
+  tasks:
+    - name: Discover registry IP
+      ansible.builtin.set_fact:
+        cifmw_rp_registry_ip: "{{ ansible_host }}"
+
+    - name: Deploy local registry
+      ansible.builtin.include_role:
+        name: registry_deploy
+
+    - name: Build and push container images
+      ansible.builtin.include_tasks: container-image-build.yml
+      loop: "{{ container_images }}"
+      loop_control:
+        loop_var: container_image
+
+    - name: Return image URLs and pause for dependent jobs
+      zuul_return:
+        data: "{{ _return_data }}"
+      vars:
+        _image_overrides: "{{ dict(_built_images | default([]) | map(attribute='update_var') | zip(_built_images | default([]) | map(attribute='url'))) }}"
+        _registry: "{{ cifmw_rp_registry_ip }}:5001"
+        _return_data: "{{ {'zuul': {'pause': true}, 'cifmw_crc_additional_insecure_registries': [_registry], 'cifmw_crc_additional_allowed_registries': [_registry]} | combine(_image_overrides) }}"


### PR DESCRIPTION
Replace the stale stf-crc-jobs template with a content-provider job that builds the sg-core container image and runs it through the telemetry functional test pipeline. Add a Makefile with docker-build and docker-push targets matching the operator convention.

Generated-By: Claude-Code claude-opus-4-6
Depends-On: https://github.com/infrawatch/feature-verification-tests/pull/345