### PR TITLE
Add image build and push make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+IMG ?= quay.io/openstack-k8s-operators/sg-core:latest
+
+.PHONY: docker-build
+docker-build: ## Build container image
+	podman build -t ${IMG} -f build/Dockerfile .
+
+.PHONY: docker-push
+docker-push: ## Push container image
+	podman push ${IMG}


### PR DESCRIPTION
Add the docker-build and docker-push make targets to build and push container images. These follow the same pattern as the operators, it's basically a direct copy from telemetry-operator's Makefile except for the image name.

This is useful to have a unified way for building images to be later used in the CI.