### PR TITLE
Add github action to execute unit tests on PRs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,18 @@
+name: Tests
+
+on:
+  pull_request:
+
+jobs:
+  unit-tests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Run unit tests
+        run: bash ci/run_tests.sh

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -ex
 
+# Only the code used in RHOSO is tested, because some of the other plugins need additional external dependencies (like a running Loki). 
 go test -v ./plugins/application/prometheus/... ./plugins/handler/ceilometer-metrics/... ./plugins/transport/socket/... ./pkg/... ./cmd/...

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -ex
+
+go test -v ./plugins/application/prometheus/... ./plugins/handler/ceilometer-metrics/... ./plugins/transport/socket/... ./pkg/... ./cmd/...

--- a/plugins/handler/ceilometer-metrics/messages/metric-tests.json
+++ b/plugins/handler/ceilometer-metrics/messages/metric-tests.json
@@ -234,9 +234,9 @@
             "availability_zone"
           ],
           "LabelVals": [
-            "operating",
+            "bb4e7d03-4e51-4ff3-8c13-a2a34a62226b",
             "telemetry.publisher.controller-0.redhat.local",
-            "loadbalancer",
+            "operating",
             "loadbalancer.operating",
             "bc25bb8f9160407ca2fdb65c5380c7f8",
             "test_project",


### PR DESCRIPTION
Automatically execute unit tests when a PR is created. Only the code used in RHOSO is tested, because some of the other plugins need additional external dependencies (like a running Loki). The testing script (really just one command) in the ci/ folder is also usable for local test execution.

Also fix ceilometer plugin unit tests

Generated-By: Claude Code claude-opus-4-6