### PR TITLE
Add check-secrets job to build-sg-core action

### DIFF
--- a/.github/workflows/build-sg-core.yaml
+++ b/.github/workflows/build-sg-core.yaml
@@ -18,10 +18,23 @@ env:
   latesttag: latest
 
 jobs:
+  check-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check secrets are set
+        id: check
+        if: "${{ env.imagenamespace == '' }}"
+        run: |
+          echo "::error title=Missing required secrets::See https://github.com/openstack-k8s-operators/dev-docs/blob/main/image_build.md#creating-images-using-github-actions"
+          echo "missing=true">>$GITHUB_OUTPUT
+    outputs:
+      missing-secrets: ${{ steps.check.outputs.missing }}
 
   build:
+    needs: check-secrets
     name: Build sg-core image using buildah
     runs-on: ubuntu-latest
+    if: needs.check-secrets.outputs.missing-secrets != 'true'
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This follows the pattern of all other openstack-k8s-operators repositories. This should get rid of receiving notifications about failed builds when pushing to private forks without having the secrets set.