### PR TITLE
[OSPRH-33508] Pin GitHub Actions to immutable commit SHAs

### DIFF
--- a/.github/workflows/build-sg-core.yaml
+++ b/.github/workflows/build-sg-core.yaml
@@ -6,6 +6,8 @@
 #    in the bundles now for offline/air gapped installation support
 
 name: sg-core image builder
+permissions:
+  contents: read
 
 on:
   push:
@@ -37,7 +39,7 @@ jobs:
     if: needs.check-secrets.outputs.missing-secrets != 'true'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
 
     - name: Set latest tag for non main branch
       if: github.ref_name != 'main'
@@ -48,7 +50,7 @@ jobs:
 
     - name: Buildah Action
       id: build
-      uses: redhat-actions/buildah-build@v2
+      uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2
       with:
         image: sg-core
         tags: ${{ env.latesttag }} ${{ github.sha }}
@@ -56,7 +58,7 @@ jobs:
           ./build/Dockerfile
 
     - name: Push sg-core To ${{ env.imageregistry }}
-      uses: redhat-actions/push-to-registry@v2
+      uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2
       with:
         image: ${{ steps.build.outputs.image }}
         tags: ${{ steps.build.outputs.tags }}
@@ -77,7 +79,7 @@ jobs:
         GITHUB_SHA: ${{ github.sha }}
 
     - name: Push tag with digest ${{ env.OPERATOR_IMAGE_DIGEST }}
-      uses: redhat-actions/push-to-registry@v2
+      uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2
       with:
         image: sg-core
         tags: ${{ env.IMAGE_DIGEST }}

--- a/.github/workflows/release-sg-core.yaml
+++ b/.github/workflows/release-sg-core.yaml
@@ -1,4 +1,6 @@
 name: Release sg-core
+permissions:
+  contents: read
 
 on:
   release:
@@ -15,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
 
     - name: Tag image
-      uses: tinact/docker.image-retag@1.0.2
+      uses: tinact/docker.image-retag@684702232e2a3c29b4e5ca25d7d80f927d255c64 # 1.0.3
       with:
         image_name: ${{ env.imagenamespace }}/sg-core
         image_old_tag: ${{ github.sha }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   pull_request:
@@ -9,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
       - name: Run unit tests


### PR DESCRIPTION
Pin all third-party action references to full 40-character commit SHAs to prevent supply-chain attacks via mutable tag retargeting. Add least-privilege `permissions: contents: read` to integration and CI workflows.

The particullar SHAs follow what we use in infrawatch/sg-core or in other openstack-k8s-operators/ repositories to unify the versions used. Due to that, some of the versions were slightly updated.